### PR TITLE
Fix program crashing with DC-state

### DIFF
--- a/code/data.py
+++ b/code/data.py
@@ -3,7 +3,12 @@ import pandas as pd
 import numpy as np
 import datetime
 import warnings
+import os
+# According to 'us' -package changelog, DC_STATEHOOD env variable should be set truthy before (FIRST) import
+# In case this is the first import, needs to be set here.
+os.environ['DC_STATEHOOD'] = '1'
 import us
+
 from convert_JHU import get_JHU
 
 class Data(object):

--- a/code/generate_predictions.py
+++ b/code/generate_predictions.py
@@ -2,8 +2,10 @@ import numpy as np
 import pandas as pd
 import json
 import argparse
-import us
+# According to 'us' -package changelog, DC_STATEHOOD env variable should be set truthy before (FIRST) import
 import os
+os.environ['DC_STATEHOOD'] = '1'
+import us
 
 from model import *
 from data import *

--- a/code/reichlab_csv.py
+++ b/code/reichlab_csv.py
@@ -2,6 +2,9 @@ import numpy as np
 import pandas as pd
 import json
 import argparse
+# According to 'us' -package changelog, DC_STATEHOOD env variable should be set truthy before (FIRST) import
+import os
+os.environ['DC_STATEHOOD'] = '1'
 import us
 
 from util import *

--- a/code/util.py
+++ b/code/util.py
@@ -8,6 +8,9 @@ import sys
 from scipy.optimize import curve_fit
 from scipy.stats import lognorm
 import json
+# According to 'us' -package changelog, DC_STATEHOOD env variable should be set truthy before (FIRST) import
+import os
+os.environ['DC_STATEHOOD'] = '1'
 import us
 
 def func(x, a, b, bias):   

--- a/code/validation.py
+++ b/code/validation.py
@@ -3,6 +3,9 @@ import pandas as pd
 from datetime import timedelta, datetime
 import json
 import argparse
+# According to 'us' -package changelog, DC_STATEHOOD env variable should be set truthy before (FIRST) import
+import os
+os.environ['DC_STATEHOOD'] = '1'
 import us
 
 from model import *


### PR DESCRIPTION
Problem was related to unclear status of District of Columbia as a US state, leading to confusion with the 'us' package devs.  Without the environment variable that I added, DC exists in package namespace but not as an actual state. This was apparently not the case when the base code was last developed.